### PR TITLE
Add carrier export/insert pipeline

### DIFF
--- a/alvys_export.py
+++ b/alvys_export.py
@@ -193,6 +193,27 @@ def export_endpoints(
             rec["FILE_ID"] = file_id
         save_json(customers, "CUSTOMERS.json", output_dir)
 
+    if "carriers" in entities:
+        carriers = fetch_paginated_data(
+            f"{urls['base_url']}/carriers/search",
+            headers,
+            {
+                "status": [
+                    "Pending",
+                    "Active",
+                    "Expired Insurance",
+                    "Interested",
+                    "Invited",
+                    "Packet Sent",
+                    "Packet Completed",
+                ],
+            },
+        )
+        file_id = get_file_id()
+        for rec in carriers:
+            rec["FILE_ID"] = file_id
+        save_json(carriers, "CARRIERS.json", output_dir)
+
 
 def main():
     args = [arg.lower() for arg in sys.argv[1:]]
@@ -314,6 +335,27 @@ def main():
         for rec in customers:
             rec["FILE_ID"] = file_id
         save_json(customers, "CUSTOMERS.json")
+
+    if run_all or "carriers" in args:
+        print("Fetching Carriers...")
+        carriers = fetch_paginated_data(
+            f"{BASE_URL}/carriers/search", headers,
+            {
+                "status": [
+                    "Pending",
+                    "Active",
+                    "Expired Insurance",
+                    "Interested",
+                    "Invited",
+                    "Packet Sent",
+                    "Packet Completed",
+                ]
+            }
+        )
+        file_id = get_file_id()
+        for rec in carriers:
+            rec["FILE_ID"] = file_id
+        save_json(carriers, "CARRIERS.json")
 
     print("\n✅ Data pull complete.")
 

--- a/alvys_insert.py
+++ b/alvys_insert.py
@@ -89,6 +89,25 @@ def sanitize_customer(c: Dict) -> Dict:
         "FILE_ID": c.get("FILE_ID")
     }
 
+def sanitize_carrier(c: Dict) -> Dict:
+    address = c.get("Address", {})
+    return {
+        "ID": c.get("Id"),
+        "CARRIER_NAME": c.get("Name"),
+        "EXTERNAL_NAME": c.get("ExternalName"),
+        "CITY": address.get("City"),
+        "STATE": address.get("State"),
+        "ZIP": address.get("ZipCode"),
+        "MC_NUM": c.get("McNum"),
+        "US_DOT_NUM": c.get("UsDotNum"),
+        "CARRIER_TYPE": c.get("Type"),
+        "CARRIER_STATUS": c.get("Status"),
+        "CARRIER_SOURCE": c.get("Source"),
+        "UPDATED_DTTM": safe_datetime(c.get("UpdatedAt")),
+        "CREATED_DTTM": safe_datetime(c.get("CreatedAt")),
+        "FILE_ID": c.get("FILE_ID"),
+    }
+
 def batch_insert(table: str, records: List[Dict], conn):
     if not records:
         print(f"No data to insert for {table}.")
@@ -138,6 +157,13 @@ def main():
         print("Loading customers JSON...")
         customers = [sanitize_customer(c) for c in load_json("CUSTOMERS.json")]
         batch_insert("ALVYS_CUSTOMERS_RAW", customers, conn)
+
+    if run_all or "carriers" in args:
+        print("Loading carriers JSON...")
+        raw = load_json("CARRIERS.json")
+        items = raw.get("Items") if isinstance(raw, dict) else raw
+        carriers = [sanitize_carrier(c) for c in items]
+        batch_insert("ALVYS_CARRIERS_RAW", carriers, conn)
 
     print("\n✅ All data inserted.")
 

--- a/inserts/active_entities_insert.py
+++ b/inserts/active_entities_insert.py
@@ -93,6 +93,25 @@ def sanitize_customer(c: Dict) -> Dict:
         "FILE_ID": c.get("FILE_ID")
     }
 
+def sanitize_carrier(c: Dict) -> Dict:
+    address = c.get("Address", {})
+    return {
+        "ID": c.get("Id"),
+        "CARRIER_NAME": c.get("Name"),
+        "EXTERNAL_NAME": c.get("ExternalName"),
+        "CITY": address.get("City"),
+        "STATE": address.get("State"),
+        "ZIP": address.get("ZipCode"),
+        "MC_NUM": c.get("McNum"),
+        "US_DOT_NUM": c.get("UsDotNum"),
+        "CARRIER_TYPE": c.get("Type"),
+        "CARRIER_STATUS": c.get("Status"),
+        "CARRIER_SOURCE": c.get("Source"),
+        "UPDATED_DTTM": safe_datetime(c.get("UpdatedAt")),
+        "CREATED_DTTM": safe_datetime(c.get("CreatedAt")),
+        "FILE_ID": c.get("FILE_ID")
+    }
+
 def batch_insert(table: str, records: List[Dict], conn):
     if not records:
         print(f"No data to insert for {table}.")
@@ -142,6 +161,13 @@ def main():
         print("Loading customers JSON...")
         customers = [sanitize_customer(c) for c in load_json("CUSTOMERS.json")]
         batch_insert("CUSTOMERS_RAW", customers, conn)
+
+    if run_all or "carriers" in args:
+        print("Loading carriers JSON...")
+        raw = load_json("CARRIERS.json")
+        items = raw.get("Items") if isinstance(raw, dict) else raw
+        carriers = [sanitize_carrier(c) for c in items]
+        batch_insert("CARRIERS_RAW", carriers, conn)
 
     print("\n✅ All data inserted.")
 

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ ENTITIES = [
     "trucks",
     "trailers",
     "customers",
+    "carriers",
 ]
 
 # ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- support carriers in export by hitting the `/carriers/search` endpoint
- flatten carrier objects for insertion with `sanitize_carrier`
- insert carriers JSON into `ALVYS_CARRIERS_RAW` and `CARRIERS_RAW`
- include carriers in CLI entity list
- remove `RECORD_ID` from carrier insert logic

## Testing
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`
- `pip install -q -r requirements.txt` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_b_6851e11f18d88333b0a1a07394697fd6